### PR TITLE
Fix Missing Tokens

### DIFF
--- a/src/driver.sml
+++ b/src/driver.sml
@@ -4,7 +4,7 @@ struct
     fun run lexer =
         let val t = lexer ()
         in
-            case lexer () of
+            case t of
                 Tokens.EOF(i,j,l) => [Tokens.EOF(i,j,l)]
               | t => t::(run lexer)
         end


### PR DESCRIPTION
Silly bug caused by calling `lexer ()` twice and only using it once.
