### PR TITLE
Fix foo() not being parsed.

### DIFF
--- a/fixtures/parser/one.tig
+++ b/fixtures/parser/one.tig
@@ -1,4 +1,5 @@
 (nil;
  123;
  -123;
- concat(chr(1+2), chr(2-2)))
+ concat(chr(1+2), chr(2-2));
+ foo())

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -55,6 +55,7 @@ seqexplist: seqexplist SEMICOLON exp ()
 negation: MINUS exp ()
 
 callexp: ID LPAREN callexplist RPAREN ()
+       | ID LPAREN RPAREN ()
 
 callexplist: callexplist COMMA exp ()
     | exp ()


### PR DESCRIPTION
This is the general form for an optional list of something separated by commas.
