### PR TITLE
Refactor And Let/Decs

### DIFF
--- a/fixtures/test42.tig
+++ b/fixtures/test42.tig
@@ -1,5 +1,5 @@
 /* correct declarations */
-let 
+let
 
 type arrtype1 = array of int
 type rectype1 = {name:string, address:string, id: int , age: int}
@@ -17,7 +17,7 @@ var rec2 := rectype2 {name="Allos", dates= arrtype1 [3] of 1900}
 
 in
 
-arr1[0] := 1; 
+arr1[0] := 1;
 arr1[9] := 3;
 arr2[3].name := "kati";
 arr2[1].age := 23;

--- a/src/parser/absyn.sml
+++ b/src/parser/absyn.sml
@@ -10,7 +10,6 @@ datatype var = SimpleVar of symbol * pos
 and exp = VarExp of var
         | NilExp
         | IntExp of int
-        | NegExp of exp * pos
         | StringExp of string * pos
         | CallExp of {func: symbol, args: exp list, pos: pos}
         | OpExp of {left: exp, oper: oper, right: exp, pos: pos}
@@ -40,7 +39,6 @@ and ty = NameTy of symbol * pos
 
 and oper = PlusOp | MinusOp | TimesOp | DivideOp
          | EqOp | NeqOp | LtOp | LeOp | GtOp | GeOp
-         | AndOp | OrOp
 
 withtype field = {name: symbol, escape: bool ref,
           typ: symbol, pos: pos}

--- a/src/parser/prabsyn.sml
+++ b/src/parser/prabsyn.sml
@@ -21,8 +21,6 @@ fun print (outstream, e0) =
     | opname A.LeOp = "LeOp"
     | opname A.GtOp = "GtOp"
     | opname A.GeOp = "GeOp"
-    | opname A.AndOp = "AndOp"
-    | opname A.OrOp = "OrOp"
 
   fun dolist d f [a] = (sayln ""; f(a,d+1))
     | dolist d f (a::r) = (sayln ""; f(a,d+1); say ","; dolist d f r)
@@ -40,8 +38,6 @@ fun print (outstream, e0) =
   and exp(A.VarExp v, d) = (indent d; sayln "VarExp("; var(v,d+1); say ")")
     | exp(A.NilExp, d) = (indent d; say "NilExp")
     | exp(A.IntExp i, d) = (indent d; say "IntExp("; say(Int.toString i);
-			    say ")")
-    | exp(A.NegExp (e, p), d) = (indent d; sayln "NegExp("; exp(e, d+1);
 			    say ")")
     | exp(A.StringExp(s,p),d) = (indent d; say "StringExp(\"";
 				 say s; say "\")")

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -1,54 +1,62 @@
 %%
-%term
-    EOF
-  | ID of string
-  | INT of int | STRING of string
-  | COMMA | COLON | SEMICOLON | LPAREN | RPAREN | LBRACK | RBRACK
-  | LBRACE | RBRACE | DOT
-  | PLUS | MINUS | TIMES | DIVIDE | EQ | NEQ | LT | LE | GT | GE
-  | AND | OR | ASSIGN
-  | ARRAY | IF | THEN | ELSE | WHILE | FOR | TO | DO | LET | IN | END | OF
-  | BREAK | NIL
-  | FUNCTION | VAR | TYPE
-  | UMINUS
+%name Tiger
 
-%nonterm exp of Absyn.exp
-       | program of Absyn.exp
-       | seqexp of Absyn.exp
-       | seqexplist of (Absyn.exp * pos) list
-       | negation of Absyn.exp
-       | callexp of Absyn.exp
-       | callexplist of Absyn.exp list
-       | arraycreateexp of Absyn.exp
-       | recordcreateexp of Absyn.exp
-       | recordcreatelistexp of (Absyn.symbol * Absyn.exp * pos) list
-       | fieldcreate of (Absyn.symbol * Absyn.exp * pos)
-       | assignmentexp of Absyn.exp
-       | lvalue of Absyn.var
-       | ifthenelseexp of Absyn.exp
-       | ifthenexp of Absyn.exp
-       | whileexp of Absyn.exp
-       | forexp of Absyn.exp
-       | letexp of Absyn.exp
-       | tyfield of Absyn.field
-       | tyfieldlist of Absyn.field list
-       | tyfields of Absyn.field list
-       | ty of Absyn.ty
-       | typedec of Absyn.dec
-       | decs of Absyn.dec list
-       | dec of Absyn.dec
-       | vardec of Absyn.dec
-       | fundecs of Absyn.dec
-       | fundeclist of Absyn.fundec list
-       | fundec of Absyn.fundec
+%term EOF
+    | ID of string
+    | INT of int
+    | STRING of string
+    | COMMA | COLON | SEMICOLON | LPAREN | RPAREN | LBRACK | RBRACK
+    | LBRACE | RBRACE | DOT
+    | PLUS | MINUS | TIMES | DIVIDE | EQ | NEQ | LT | LE | GT | GE
+    | AND | OR | ASSIGN
+    | ARRAY | IF | THEN | ELSE | WHILE | FOR | TO | DO | LET | IN | END | OF
+    | BREAK | NIL
+    | FUNCTION | VAR | TYPE
+    | UMINUS
 
+%nonterm program         of Absyn.exp
+       | var             of Absyn.var
+       | exp             of Absyn.exp
+       | callexp         of Absyn.exp
+       | callexplist     of Absyn.exp list
+       | recordexp       of Absyn.exp
+       | recordexplist   of (Absyn.symbol * Absyn.exp * pos) list
+       | recordexpfields of (Absyn.symbol * Absyn.exp * pos)
+       | seqexp          of Absyn.exp
+       | seqexplist      of (Absyn.exp * pos) list
+       | assignexp       of Absyn.exp
+       | ifthenelseexp   of Absyn.exp
+       | ifthenexp       of Absyn.exp
+       | whileexp        of Absyn.exp
+       | forexp          of Absyn.exp
+       | arrayexp        of Absyn.exp
+       | letexp          of Absyn.exp
+       | dec             of Absyn.dec
+       | declist         of Absyn.dec list
+       | fundec          of Absyn.fundec
+       | fundeclist      of Absyn.fundec list
+       | vardec          of Absyn.dec
+       | typedec         of {name: Absyn.symbol, ty: Absyn.ty, pos: pos}
+       | typedeclist     of {name: Absyn.symbol, ty: Absyn.ty, pos: pos} list
+       | ty              of Absyn.ty
+       | tyfield         of Absyn.field
+       | tyfieldlist     of Absyn.field list
+
+
+
+
+
+
+
+%keyword WHILE FOR TO BREAK LET IN END FUNCTION VAR TYPE ARRAY IF THEN ELSE
+         DO OF NIL
 
 %nonassoc FUNCTION VAR TYPE IN
 %nonassoc ID
 %nonassoc THEN DO
 %nonassoc ELSE OF
 %left ASSIGN LBRACK
-%left OR AND (* Does precedence matter here? *)
+%left OR AND
 %nonassoc EQ NEQ LE LT GT GE
 %left PLUS MINUS
 %left TIMES DIVIDE
@@ -60,12 +68,7 @@
 %eop EOF
 %noshift EOF
 
-%name Tiger
-
-%keyword WHILE FOR TO BREAK LET IN END FUNCTION VAR TYPE ARRAY IF THEN ELSE
-	DO OF NIL
-
-%prefer THEN ELSE LPAREN 
+%prefer THEN ELSE LPAREN
 
 %value ID ("bogus")
 %value INT (1)
@@ -73,114 +76,161 @@
 
 %%
 
-(* This is a skeleton grammar file, meant to illustrate what kind of
- * declarations are necessary above the %% mark.  Students are expected
- *  to replace the two dummy productions below with an actual grammar.
- *)
-
 program : exp (exp)
 
+var: ID                    (Absyn.SimpleVar(Symbol.symbol(ID), IDleft))
+   | var DOT ID            (Absyn.FieldVar(var, Symbol.symbol(ID), varleft))
+   | var LBRACK exp RBRACK (Absyn.SubscriptVar(var, exp, varleft))
 
-exp: lvalue          (Absyn.VarExp(lvalue))
-   | NIL             (Absyn.NilExp)
-   | INT             (Absyn.IntExp(INT))
-   | STRING          (Absyn.StringExp(STRING, STRINGleft))
-   | seqexp          (seqexp)
-   | negation        (negation)
-   | callexp         (callexp)
-   | arraycreateexp  (arraycreateexp)
-   | recordcreateexp (recordcreateexp)
-   | assignmentexp   (assignmentexp)
-
-   | exp PLUS exp   (Absyn.OpExp { left=exp1, oper=Absyn.PlusOp, right=exp2, pos=exp1left })
-   | exp MINUS exp  (Absyn.OpExp { left=exp1, oper=Absyn.MinusOp, right=exp2, pos=exp1left })
-   | exp TIMES exp  (Absyn.OpExp { left=exp1, oper=Absyn.TimesOp, right=exp2, pos=exp1left })
-   | exp DIVIDE exp (Absyn.OpExp { left=exp1, oper=Absyn.DivideOp, right=exp2, pos=exp1left })
-   | exp AND exp    (Absyn.OpExp { left=exp1, oper=Absyn.AndOp, right=exp2, pos=exp1left })
-   | exp OR exp     (Absyn.OpExp { left=exp1, oper=Absyn.OrOp, right=exp2, pos=exp1left })
-   | exp EQ exp     (Absyn.OpExp { left=exp1, oper=Absyn.EqOp, right=exp2, pos=exp1left })
-   | exp NEQ exp    (Absyn.OpExp { left=exp1, oper=Absyn.NeqOp, right=exp2, pos=exp1left })
-   | exp LT exp     (Absyn.OpExp { left=exp1, oper=Absyn.LtOp, right=exp2, pos=exp1left })
-   | exp LE exp     (Absyn.OpExp { left=exp1, oper=Absyn.LeOp, right=exp2, pos=exp1left })
-   | exp GT exp     (Absyn.OpExp { left=exp1, oper=Absyn.GtOp, right=exp2, pos=exp1left })
-   | exp GE exp     (Absyn.OpExp { left=exp1, oper=Absyn.GeOp, right=exp2, pos=exp1left })
-
-   | ifthenelseexp (ifthenelseexp)
-   | ifthenexp     (ifthenexp)
-   | whileexp      (whileexp)
-   | forexp        (forexp)
-   | BREAK         (Absyn.BreakExp(BREAKleft))
-   | letexp        (letexp)
-
-negation: MINUS exp %prec UMINUS (Absyn.NegExp(exp, MINUSleft))
-
-seqexp: LPAREN seqexplist RPAREN (Absyn.SeqExp(List.rev(seqexplist)))
-
-seqexplist: seqexplist SEMICOLON exp ((exp, expleft)::seqexplist)
-    | exp                            ([(exp, expleft)])
-    |                                ([])
-
-callexp: ID LPAREN callexplist RPAREN (Absyn.CallExp { func=Symbol.symbol(ID), args=List.rev(callexplist), pos=IDleft})
-
-callexplist: callexplist COMMA exp (exp :: callexplist)
-    | exp                          ([exp])
-    |                              ([])
-
-arraycreateexp: ID LBRACK exp RBRACK OF exp (Absyn.ArrayExp { typ=Symbol.symbol(ID), size=exp1, init=exp2, pos=IDleft })
-
-recordcreateexp: ID LBRACE recordcreatelistexp RBRACE (Absyn.RecordExp { fields=List.rev(recordcreatelistexp), typ=Symbol.symbol(ID), pos=IDleft })
-
-recordcreatelistexp: recordcreatelistexp COMMA fieldcreate (fieldcreate :: recordcreatelistexp)
-    | fieldcreate                                    ([fieldcreate])
-
-fieldcreate: ID EQ exp ((Symbol.symbol(ID), exp, IDleft))
-
-assignmentexp: lvalue ASSIGN exp (Absyn.AssignExp { var=lvalue, exp=exp, pos=lvalueleft })
-
-lvalue: ID                     (Absyn.SimpleVar(Symbol.symbol(ID), IDleft))
-    | lvalue DOT ID            (Absyn.FieldVar(lvalue, Symbol.symbol(ID), lvalueleft))
-    | lvalue LBRACK exp RBRACK (Absyn.SubscriptVar(lvalue, exp, lvalueleft))
-
-ifthenelseexp: IF exp THEN exp ELSE exp (Absyn.IfExp { test=exp1, then'=exp2, else'=Option.SOME(exp3), pos=IFleft })
-
-ifthenexp: IF exp THEN exp (Absyn.IfExp { test=exp1, then'=exp2, else'=Option.NONE, pos=IFleft })
-
-whileexp: WHILE exp DO exp (Absyn.WhileExp { test=exp1, body=exp2, pos=WHILEleft })
-
-forexp: FOR ID ASSIGN exp TO exp DO exp (Absyn.ForExp { var=Symbol.symbol(ID), escape=ref false, lo=exp1, hi=exp2, body=exp3, pos=FORleft })
-
-letexp: LET decs IN exp END (Absyn.LetExp {decs=List.rev decs, body=exp, pos=LETleft})
-
-decs: dec      ([dec])
-    | decs dec (dec::decs)
-
-dec: typedec (typedec)
-    | vardec (vardec)
-    | fundecs (fundecs)
+exp: var                    (Absyn.VarExp(var))
+   | NIL                    (Absyn.NilExp)
+   | INT                    (Absyn.IntExp(INT))
+   | MINUS exp %prec UMINUS (Absyn.NegExp(exp, MINUSleft))
+   | STRING                 (Absyn.StringExp(STRING, STRINGleft))
+   | callexp                (callexp)
+   | exp PLUS exp           (Absyn.OpExp { left=exp1, oper=Absyn.PlusOp, right=exp2, pos=exp1left })
+   | exp MINUS exp          (Absyn.OpExp { left=exp1, oper=Absyn.MinusOp, right=exp2, pos=exp1left })
+   | exp TIMES exp          (Absyn.OpExp { left=exp1, oper=Absyn.TimesOp, right=exp2, pos=exp1left })
+   | exp DIVIDE exp         (Absyn.OpExp { left=exp1, oper=Absyn.DivideOp, right=exp2, pos=exp1left })
+   | exp AND exp            (Absyn.OpExp { left=exp1, oper=Absyn.AndOp, right=exp2, pos=exp1left })
+   | exp OR exp             (Absyn.OpExp { left=exp1, oper=Absyn.OrOp, right=exp2, pos=exp1left })
+   | exp EQ exp             (Absyn.OpExp { left=exp1, oper=Absyn.EqOp, right=exp2, pos=exp1left })
+   | exp NEQ exp            (Absyn.OpExp { left=exp1, oper=Absyn.NeqOp, right=exp2, pos=exp1left })
+   | exp LT exp             (Absyn.OpExp { left=exp1, oper=Absyn.LtOp, right=exp2, pos=exp1left })
+   | exp LE exp             (Absyn.OpExp { left=exp1, oper=Absyn.LeOp, right=exp2, pos=exp1left })
+   | exp GT exp             (Absyn.OpExp { left=exp1, oper=Absyn.GtOp, right=exp2, pos=exp1left })
+   | exp GE exp             (Absyn.OpExp { left=exp1, oper=Absyn.GeOp, right=exp2, pos=exp1left })
+   | recordexp              (recordexp)
+   | seqexp                 (seqexp)
+   | assignexp              (assignexp)
+   | ifthenelseexp          (ifthenelseexp)
+   | ifthenexp              (ifthenexp)
+   | whileexp               (whileexp)
+   | forexp                 (forexp)
+   | BREAK                  (Absyn.BreakExp(BREAKleft))
+   | arrayexp               (arrayexp)
+   | letexp                 (letexp)
 
 
-typedec: TYPE ID EQ ty (Absyn.TypeDec [{name=Symbol.symbol ID, ty=ty, pos=TYPEleft}])
+callexp: ID LPAREN callexplist RPAREN    (Absyn.CallExp { func=Symbol.symbol(ID),
+                                                          args=List.rev(callexplist),
+                                                          pos=IDleft })
 
-ty: ID                       (Absyn.NameTy (Symbol.symbol ID, IDleft))
-    | LBRACE tyfields RBRACE (Absyn.RecordTy tyfields)
-    | ARRAY OF ID            (Absyn.ArrayTy (Symbol.symbol ID, ARRAYleft))
+callexplist: callexplist COMMA exp    (exp :: callexplist)
+           | exp                      ([exp])
+           |                          ([])
 
-tyfields: tyfieldlist (List.rev tyfieldlist)
-    |                 ([])
 
-tyfieldlist: tyfield            ([tyfield])
-    | tyfieldlist COMMA tyfield (tyfield::tyfieldlist)
+recordexp: ID LBRACE recordexplist RBRACE    (Absyn.RecordExp { fields=List.rev(recordexplist),
+                                                                typ=Symbol.symbol(ID),
+                                                                pos=IDleft })
 
-tyfield: ID COLON ID ({name=Symbol.symbol(ID1), typ=Symbol.symbol(ID2), escape=ref true, pos=ID1left})
+recordexplist: recordexplist COMMA recordexpfields    (recordexpfields :: recordexplist)
+             | recordexpfields                        ([recordexpfields])
 
-vardec: VAR ID ASSIGN exp        (Absyn.VarDec {name=Symbol.symbol ID, escape=ref true, typ=Option.NONE, pos=VARleft})
-    | VAR ID COLON ID ASSIGN exp (Absyn.VarDec {name=Symbol.symbol ID1, escape=ref true, typ=Option.SOME (Symbol.symbol ID2, ID2left), pos=VARleft})
+recordexpfields: ID EQ exp    ((Symbol.symbol(ID), exp, IDleft))
 
-fundecs: fundeclist (Absyn.FunctionDec (List.rev fundeclist))
-    |               (Absyn.FunctionDec [])
 
-fundeclist: fundec      ([fundec])
-    | fundeclist fundec (fundec::fundeclist)
+seqexp: LPAREN seqexplist RPAREN    (Absyn.SeqExp(List.rev(seqexplist)))
 
-fundec: FUNCTION ID LPAREN tyfields RPAREN EQ exp        ({name=Symbol.symbol ID, params=tyfields, result=Option.NONE, body=exp, pos=FUNCTIONleft})
-    | FUNCTION ID LPAREN tyfields RPAREN COLON ID EQ exp ({name=Symbol.symbol ID1, params=tyfields, result=Option.SOME (Symbol.symbol ID2, ID2left), body=exp, pos=FUNCTIONleft})
+seqexplist: seqexplist SEMICOLON exp    ((exp, expleft) :: seqexplist)
+          | exp                         ([(exp, expleft)])
+          |                             ([])
+
+
+assignexp: var ASSIGN exp    (Absyn.AssignExp { var=var,
+                                                exp=exp,
+                                                pos=varleft })
+
+
+ifthenelseexp: IF exp THEN exp ELSE exp    (Absyn.IfExp { test=exp1,
+                                                          then'=exp2,
+                                                          else'=Option.SOME(exp3),
+                                                          pos=IFleft })
+
+
+ifthenexp: IF exp THEN exp    (Absyn.IfExp { test=exp1,
+                                             then'=exp2,
+                                             else'=Option.NONE,
+                                             pos=IFleft })
+
+
+whileexp: WHILE exp DO exp    (Absyn.WhileExp { test=exp1,
+                                                body=exp2,
+                                                pos=WHILEleft })
+
+
+forexp: FOR ID ASSIGN exp TO exp DO exp    (Absyn.ForExp { var=Symbol.symbol(ID),
+                                                           escape=ref true,
+                                                           lo=exp1,
+                                                           hi=exp2,
+                                                           body=exp3,
+                                                           pos=FORleft })
+
+
+arrayexp: ID LBRACK exp RBRACK OF exp (Absyn.ArrayExp { typ=Symbol.symbol(ID),
+                                                        size=exp1,
+                                                        init=exp2,
+                                                        pos=IDleft })
+
+
+letexp: LET declist IN exp END (Absyn.LetExp { decs=List.rev declist,
+                                               body=exp,
+                                               pos=LETleft })
+
+
+dec: fundeclist     (Absyn.FunctionDec(fundeclist))
+   | vardec         (vardec)
+   | typedeclist    (Absyn.TypeDec(typedeclist))
+
+declist: declist dec    (dec :: declist)
+       | dec            ([dec])
+
+
+fundec: FUNCTION ID LPAREN tyfieldlist RPAREN EQ exp             ({ name=Symbol.symbol(ID),
+                                                                    params=tyfieldlist,
+                                                                    result=Option.NONE,
+                                                                    body=exp,
+                                                                    pos=FUNCTIONleft })
+      | FUNCTION ID LPAREN tyfieldlist RPAREN COLON ID EQ exp    ({ name=Symbol.symbol(ID1),
+                                                                    params=tyfieldlist,
+                                                                    result=Option.SOME(Symbol.symbol(ID2), ID2left),
+                                                                    body=exp,
+                                                                    pos=FUNCTIONleft })
+
+fundeclist: fundeclist fundec    (fundec :: fundeclist)
+          | fundec               ([fundec])
+
+
+vardec: VAR ID ASSIGN exp            (Absyn.VarDec { name=Symbol.symbol(ID),
+                                                     escape=ref true,
+                                                     typ=Option.NONE,
+                                                     init=exp,
+                                                     pos=VARleft })
+     | VAR ID COLON ID ASSIGN exp    (Absyn.VarDec { name=Symbol.symbol(ID1),
+                                                     escape=ref true,
+                                                     typ=Option.SOME(Symbol.symbol(ID2), ID2left),
+                                                     init=exp,
+                                                     pos=VARleft })
+
+
+typedec: TYPE ID EQ ty    ({ name=Symbol.symbol(ID),
+                             ty=ty,
+                             pos=TYPEleft })
+
+typedeclist: typedeclist typedec    (typedec :: typedeclist)
+           | typedec                ([typedec])
+
+
+ty: ID                           (Absyn.NameTy (Symbol.symbol(ID), IDleft))
+  | LBRACE tyfieldlist RBRACE    (Absyn.RecordTy tyfieldlist)
+  | ARRAY OF ID                  (Absyn.ArrayTy (Symbol.symbol(ID), ARRAYleft))
+
+
+tyfield: ID COLON ID    ({ name=Symbol.symbol(ID1),
+                           escape=ref true,
+                           typ=Symbol.symbol(ID2),
+                           pos=ID1left })
+
+tyfieldlist: tyfieldlist COMMA tyfield    (tyfield :: tyfieldlist)
+           | tyfield                      ([tyfield])

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -1,3 +1,5 @@
+open Absyn;
+
 %%
 %name Tiger
 
@@ -14,33 +16,33 @@
     | FUNCTION | VAR | TYPE
     | UMINUS
 
-%nonterm program         of Absyn.exp
-       | var             of Absyn.var
-       | exp             of Absyn.exp
-       | callexp         of Absyn.exp
-       | callexplist     of Absyn.exp list
-       | recordexp       of Absyn.exp
-       | recordexplist   of (Absyn.symbol * Absyn.exp * pos) list
-       | recordexpfields of (Absyn.symbol * Absyn.exp * pos)
-       | seqexp          of Absyn.exp
-       | seqexplist      of (Absyn.exp * pos) list
-       | assignexp       of Absyn.exp
-       | ifthenelseexp   of Absyn.exp
-       | ifthenexp       of Absyn.exp
-       | whileexp        of Absyn.exp
-       | forexp          of Absyn.exp
-       | arrayexp        of Absyn.exp
-       | letexp          of Absyn.exp
-       | dec             of Absyn.dec
-       | declist         of Absyn.dec list
-       | fundec          of Absyn.fundec
-       | fundeclist      of Absyn.fundec list
-       | vardec          of Absyn.dec
-       | typedec         of {name: Absyn.symbol, ty: Absyn.ty, pos: pos}
-       | typedeclist     of {name: Absyn.symbol, ty: Absyn.ty, pos: pos} list
-       | ty              of Absyn.ty
-       | tyfield         of Absyn.field
-       | tyfieldlist     of Absyn.field list
+%nonterm program         of exp
+       | var             of var
+       | exp             of exp
+       | callexp         of exp
+       | callexplist     of exp list
+       | recordexp       of exp
+       | recordexplist   of (symbol * exp * pos) list
+       | recordexpfields of (symbol * exp * pos)
+       | seqexp          of exp
+       | seqexplist      of (exp * pos) list
+       | assignexp       of exp
+       | ifthenelseexp   of exp
+       | ifthenexp       of exp
+       | whileexp        of exp
+       | forexp          of exp
+       | arrayexp        of exp
+       | letexp          of exp
+       | dec             of dec
+       | declist         of dec list
+       | fundec          of fundec
+       | fundeclist      of fundec list
+       | vardec          of dec
+       | typedec         of {name: symbol, ty: ty, pos: pos}
+       | typedeclist     of {name: symbol, ty: ty, pos: pos} list
+       | ty              of ty
+       | tyfield         of field
+       | tyfieldlist     of field list
 
 
 
@@ -78,34 +80,34 @@
 
 program : exp (exp)
 
-var: ID                    (Absyn.SimpleVar(Symbol.symbol(ID), IDleft))
-   | var DOT ID            (Absyn.FieldVar(var, Symbol.symbol(ID), varleft))
-   | var LBRACK exp RBRACK (Absyn.SubscriptVar(var, exp, varleft))
+var: ID                    (SimpleVar(Symbol.symbol(ID), IDleft))
+   | var DOT ID            (FieldVar(var, Symbol.symbol(ID), varleft))
+   | var LBRACK exp RBRACK (SubscriptVar(var, exp, varleft))
 
-exp: var                    (Absyn.VarExp(var))
-   | NIL                    (Absyn.NilExp)
-   | INT                    (Absyn.IntExp(INT))
-   | MINUS exp %prec UMINUS (Absyn.OpExp { left=Absyn.IntExp(0), oper=Absyn.MinusOp, right=exp, pos=MINUSleft })
-   | STRING                 (Absyn.StringExp(STRING, STRINGleft))
+exp: var                    (VarExp(var))
+   | NIL                    (NilExp)
+   | INT                    (IntExp(INT))
+   | MINUS exp %prec UMINUS (OpExp { left=IntExp(0), oper=MinusOp, right=exp, pos=MINUSleft })
+   | STRING                 (StringExp(STRING, STRINGleft))
    | callexp                (callexp)
-   | exp PLUS exp           (Absyn.OpExp { left=exp1, oper=Absyn.PlusOp, right=exp2, pos=exp1left })
-   | exp MINUS exp          (Absyn.OpExp { left=exp1, oper=Absyn.MinusOp, right=exp2, pos=exp1left })
-   | exp TIMES exp          (Absyn.OpExp { left=exp1, oper=Absyn.TimesOp, right=exp2, pos=exp1left })
-   | exp DIVIDE exp         (Absyn.OpExp { left=exp1, oper=Absyn.DivideOp, right=exp2, pos=exp1left })
-   | exp AND exp            (Absyn.IfExp { test=exp1,
+   | exp PLUS exp           (OpExp { left=exp1, oper=PlusOp, right=exp2, pos=exp1left })
+   | exp MINUS exp          (OpExp { left=exp1, oper=MinusOp, right=exp2, pos=exp1left })
+   | exp TIMES exp          (OpExp { left=exp1, oper=TimesOp, right=exp2, pos=exp1left })
+   | exp DIVIDE exp         (OpExp { left=exp1, oper=DivideOp, right=exp2, pos=exp1left })
+   | exp AND exp            (IfExp { test=exp1,
                                            then'=exp2,
-                                           else'=Option.SOME(Absyn.IntExp(0)),
+                                           else'=Option.SOME(IntExp(0)),
                                            pos=exp1left })
-   | exp OR exp             (Absyn.IfExp { test=exp1,
-                                           then'=Absyn.IntExp(1),
+   | exp OR exp             (IfExp { test=exp1,
+                                           then'=IntExp(1),
                                            else'=Option.SOME(exp2),
                                            pos=exp1left })
-   | exp EQ exp             (Absyn.OpExp { left=exp1, oper=Absyn.EqOp, right=exp2, pos=exp1left })
-   | exp NEQ exp            (Absyn.OpExp { left=exp1, oper=Absyn.NeqOp, right=exp2, pos=exp1left })
-   | exp LT exp             (Absyn.OpExp { left=exp1, oper=Absyn.LtOp, right=exp2, pos=exp1left })
-   | exp LE exp             (Absyn.OpExp { left=exp1, oper=Absyn.LeOp, right=exp2, pos=exp1left })
-   | exp GT exp             (Absyn.OpExp { left=exp1, oper=Absyn.GtOp, right=exp2, pos=exp1left })
-   | exp GE exp             (Absyn.OpExp { left=exp1, oper=Absyn.GeOp, right=exp2, pos=exp1left })
+   | exp EQ exp             (OpExp { left=exp1, oper=EqOp, right=exp2, pos=exp1left })
+   | exp NEQ exp            (OpExp { left=exp1, oper=NeqOp, right=exp2, pos=exp1left })
+   | exp LT exp             (OpExp { left=exp1, oper=LtOp, right=exp2, pos=exp1left })
+   | exp LE exp             (OpExp { left=exp1, oper=LeOp, right=exp2, pos=exp1left })
+   | exp GT exp             (OpExp { left=exp1, oper=GtOp, right=exp2, pos=exp1left })
+   | exp GE exp             (OpExp { left=exp1, oper=GeOp, right=exp2, pos=exp1left })
    | recordexp              (recordexp)
    | seqexp                 (seqexp)
    | assignexp              (assignexp)
@@ -113,12 +115,12 @@ exp: var                    (Absyn.VarExp(var))
    | ifthenexp              (ifthenexp)
    | whileexp               (whileexp)
    | forexp                 (forexp)
-   | BREAK                  (Absyn.BreakExp(BREAKleft))
+   | BREAK                  (BreakExp(BREAKleft))
    | arrayexp               (arrayexp)
    | letexp                 (letexp)
 
 
-callexp: ID LPAREN callexplist RPAREN    (Absyn.CallExp { func=Symbol.symbol(ID),
+callexp: ID LPAREN callexplist RPAREN    (CallExp { func=Symbol.symbol(ID),
                                                           args=List.rev(callexplist),
                                                           pos=IDleft })
 
@@ -127,7 +129,7 @@ callexplist: callexplist COMMA exp    (exp :: callexplist)
            |                          ([])
 
 
-recordexp: ID LBRACE recordexplist RBRACE    (Absyn.RecordExp { fields=List.rev(recordexplist),
+recordexp: ID LBRACE recordexplist RBRACE    (RecordExp { fields=List.rev(recordexplist),
                                                                 typ=Symbol.symbol(ID),
                                                                 pos=IDleft })
 
@@ -138,36 +140,36 @@ recordexplist: recordexplist COMMA recordexpfields    (recordexpfields :: record
 recordexpfields: ID EQ exp    ((Symbol.symbol(ID), exp, IDleft))
 
 
-seqexp: LPAREN seqexplist RPAREN    (Absyn.SeqExp(List.rev(seqexplist)))
+seqexp: LPAREN seqexplist RPAREN    (SeqExp(List.rev(seqexplist)))
 
 seqexplist: seqexplist SEMICOLON exp    ((exp, expleft) :: seqexplist)
           | exp                         ([(exp, expleft)])
           |                             ([])
 
 
-assignexp: var ASSIGN exp    (Absyn.AssignExp { var=var,
+assignexp: var ASSIGN exp    (AssignExp { var=var,
                                                 exp=exp,
                                                 pos=varleft })
 
 
-ifthenelseexp: IF exp THEN exp ELSE exp    (Absyn.IfExp { test=exp1,
+ifthenelseexp: IF exp THEN exp ELSE exp    (IfExp { test=exp1,
                                                           then'=exp2,
                                                           else'=Option.SOME(exp3),
                                                           pos=IFleft })
 
 
-ifthenexp: IF exp THEN exp    (Absyn.IfExp { test=exp1,
+ifthenexp: IF exp THEN exp    (IfExp { test=exp1,
                                              then'=exp2,
                                              else'=Option.NONE,
                                              pos=IFleft })
 
 
-whileexp: WHILE exp DO exp    (Absyn.WhileExp { test=exp1,
+whileexp: WHILE exp DO exp    (WhileExp { test=exp1,
                                                 body=exp2,
                                                 pos=WHILEleft })
 
 
-forexp: FOR ID ASSIGN exp TO exp DO exp    (Absyn.ForExp { var=Symbol.symbol(ID),
+forexp: FOR ID ASSIGN exp TO exp DO exp    (ForExp { var=Symbol.symbol(ID),
                                                            escape=ref true,
                                                            lo=exp1,
                                                            hi=exp2,
@@ -175,20 +177,20 @@ forexp: FOR ID ASSIGN exp TO exp DO exp    (Absyn.ForExp { var=Symbol.symbol(ID)
                                                            pos=FORleft })
 
 
-arrayexp: ID LBRACK exp RBRACK OF exp (Absyn.ArrayExp { typ=Symbol.symbol(ID),
+arrayexp: ID LBRACK exp RBRACK OF exp (ArrayExp { typ=Symbol.symbol(ID),
                                                         size=exp1,
                                                         init=exp2,
                                                         pos=IDleft })
 
 
-letexp: LET declist IN exp END (Absyn.LetExp { decs=List.rev declist,
+letexp: LET declist IN exp END (LetExp { decs=List.rev declist,
                                                body=exp,
                                                pos=LETleft })
 
 
-dec: fundeclist     (Absyn.FunctionDec(fundeclist))
+dec: fundeclist     (FunctionDec(fundeclist))
    | vardec         (vardec)
-   | typedeclist    (Absyn.TypeDec(typedeclist))
+   | typedeclist    (TypeDec(typedeclist))
 
 declist: declist dec    (dec :: declist)
        | dec            ([dec])
@@ -209,12 +211,12 @@ fundeclist: fundeclist fundec    (fundec :: fundeclist)
           | fundec               ([fundec])
 
 
-vardec: VAR ID ASSIGN exp            (Absyn.VarDec { name=Symbol.symbol(ID),
+vardec: VAR ID ASSIGN exp            (VarDec { name=Symbol.symbol(ID),
                                                      escape=ref true,
                                                      typ=Option.NONE,
                                                      init=exp,
                                                      pos=VARleft })
-     | VAR ID COLON ID ASSIGN exp    (Absyn.VarDec { name=Symbol.symbol(ID1),
+     | VAR ID COLON ID ASSIGN exp    (VarDec { name=Symbol.symbol(ID1),
                                                      escape=ref true,
                                                      typ=Option.SOME(Symbol.symbol(ID2), ID2left),
                                                      init=exp,
@@ -229,9 +231,9 @@ typedeclist: typedeclist typedec    (typedec :: typedeclist)
            | typedec                ([typedec])
 
 
-ty: ID                           (Absyn.NameTy (Symbol.symbol(ID), IDleft))
-  | LBRACE tyfieldlist RBRACE    (Absyn.RecordTy tyfieldlist)
-  | ARRAY OF ID                  (Absyn.ArrayTy (Symbol.symbol(ID), ARRAYleft))
+ty: ID                           (NameTy (Symbol.symbol(ID), IDleft))
+  | LBRACE tyfieldlist RBRACE    (RecordTy tyfieldlist)
+  | ARRAY OF ID                  (ArrayTy (Symbol.symbol(ID), ARRAYleft))
 
 
 tyfield: ID COLON ID    ({ name=Symbol.symbol(ID1),

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -85,15 +85,21 @@ var: ID                    (Absyn.SimpleVar(Symbol.symbol(ID), IDleft))
 exp: var                    (Absyn.VarExp(var))
    | NIL                    (Absyn.NilExp)
    | INT                    (Absyn.IntExp(INT))
-   | MINUS exp %prec UMINUS (Absyn.NegExp(exp, MINUSleft))
+   | MINUS exp %prec UMINUS (Absyn.OpExp { left=Absyn.IntExp(0), oper=Absyn.MinusOp, right=exp, pos=MINUSleft })
    | STRING                 (Absyn.StringExp(STRING, STRINGleft))
    | callexp                (callexp)
    | exp PLUS exp           (Absyn.OpExp { left=exp1, oper=Absyn.PlusOp, right=exp2, pos=exp1left })
    | exp MINUS exp          (Absyn.OpExp { left=exp1, oper=Absyn.MinusOp, right=exp2, pos=exp1left })
    | exp TIMES exp          (Absyn.OpExp { left=exp1, oper=Absyn.TimesOp, right=exp2, pos=exp1left })
    | exp DIVIDE exp         (Absyn.OpExp { left=exp1, oper=Absyn.DivideOp, right=exp2, pos=exp1left })
-   | exp AND exp            (Absyn.OpExp { left=exp1, oper=Absyn.AndOp, right=exp2, pos=exp1left })
-   | exp OR exp             (Absyn.OpExp { left=exp1, oper=Absyn.OrOp, right=exp2, pos=exp1left })
+   | exp AND exp            (Absyn.IfExp { test=exp1,
+                                           then'=exp2,
+                                           else'=Option.SOME(Absyn.IntExp(0)),
+                                           pos=exp1left })
+   | exp OR exp             (Absyn.IfExp { test=exp1,
+                                           then'=Absyn.IntExp(1),
+                                           else'=Option.SOME(exp2),
+                                           pos=exp1left })
    | exp EQ exp             (Absyn.OpExp { left=exp1, oper=Absyn.EqOp, right=exp2, pos=exp1left })
    | exp NEQ exp            (Absyn.OpExp { left=exp1, oper=Absyn.NeqOp, right=exp2, pos=exp1left })
    | exp LT exp             (Absyn.OpExp { left=exp1, oper=Absyn.LtOp, right=exp2, pos=exp1left })

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -50,14 +50,20 @@ open Absyn;
          DO OF NIL
 
 %nonassoc FUNCTION VAR TYPE IN
+
 %nonassoc ID
-%nonassoc THEN DO
-%nonassoc ELSE OF
-%left ASSIGN LBRACK
-%left OR AND
+
+%nonassoc THEN
+%nonassoc ELSE OF DO
+(* An assignment is a valueless expression *)
+%nonassoc ASSIGN
+(* The comparison operations are non-associative *)
+%nonassoc OR AND
 %nonassoc EQ NEQ LE LT GT GE
+(* This follows from common mathematics *)
 %left PLUS MINUS
 %left TIMES DIVIDE
+(* Unary minus binds the tightest of all. *)
 %left UMINUS
 
 %pos int
@@ -78,7 +84,7 @@ program : exp (exp)
 
 var: ID                       (SimpleVar(Symbol.symbol(ID), IDleft))
    | var DOT ID               (FieldVar(var, Symbol.symbol(ID), varleft))
-   | var LBRACK exp RBRACK    (SubscriptVar(var, exp, varleft))
+   (*| var LBRACK exp RBRACK    (SubscriptVar(var, exp, varleft))*)
 
 exp: var                       (VarExp(var))
    | NIL                       (NilExp)

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -19,6 +19,7 @@ open Absyn;
 %nonterm program         of exp
        | var             of var
        | exp             of exp
+       | explist         of (exp * pos) list
        | opexp           of exp
        | callexp         of exp
        | callexplist     of exp list
@@ -97,6 +98,11 @@ exp: var                       (VarExp(var))
    | arrayexp                  (arrayexp)
    | letexp                    (letexp)
 
+explist: explist SEMICOLON exp    ((exp, explistleft) :: explist)
+       | exp                      ([(exp, expleft)])
+       |                          ([])
+
+
 opexp: exp PLUS exp      (OpExp { left=exp1,oper=PlusOp,   right=exp2,pos=exp1left })
      | exp MINUS exp     (OpExp { left=exp1,oper=MinusOp,  right=exp2,pos=exp1left })
      | exp TIMES exp     (OpExp { left=exp1,oper=TimesOp,  right=exp2,pos=exp1left })
@@ -174,9 +180,9 @@ arrayexp: ID LBRACK exp RBRACK OF exp (ArrayExp { typ=Symbol.symbol(ID),
                                                   pos=IDleft })
 
 
-letexp: LET declist IN exp END (LetExp { decs=List.rev declist,
-                                         body=exp,
-                                         pos=LETleft })
+letexp: LET declist IN explist END (LetExp { decs=List.rev declist,
+                                             body=SeqExp(List.rev(explist)),
+                                             pos=LETleft })
 
 
 dec: fundeclist     (FunctionDec(List.rev(fundeclist)))

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -14,7 +14,7 @@ open Absyn;
     | ARRAY | IF | THEN | ELSE | WHILE | FOR | TO | DO | LET | IN | END | OF
     | BREAK | NIL
     | FUNCTION | VAR | TYPE
-    | UMINUS
+    | UMINUS | DEC
 
 %nonterm program         of exp
        | var             of var
@@ -49,14 +49,20 @@ open Absyn;
 %keyword WHILE FOR TO BREAK LET IN END FUNCTION VAR TYPE ARRAY IF THEN ELSE
          DO OF NIL
 
-%nonassoc FUNCTION VAR TYPE IN
-
+(* This is used as the type and function declaration precedence
+   so it does not interfere with the tokens type and function themselves *)
+%nonassoc DEC
+%nonassoc TYPE
+%nonassoc FUNCTION
 %nonassoc ID
+%nonassoc LBRACK
 
+(* Handles the dangling else problem *)
 %nonassoc THEN
-%nonassoc ELSE OF DO
+%nonassoc ELSE DO
 (* An assignment is a valueless expression *)
 %nonassoc ASSIGN
+%nonassoc OF
 (* The comparison operations are non-associative *)
 %nonassoc OR AND
 %nonassoc EQ NEQ LE LT GT GE
@@ -65,6 +71,7 @@ open Absyn;
 %left TIMES DIVIDE
 (* Unary minus binds the tightest of all. *)
 %left UMINUS
+
 
 %pos int
 %verbose
@@ -84,7 +91,8 @@ program : exp (exp)
 
 var: ID                       (SimpleVar(Symbol.symbol(ID), IDleft))
    | var DOT ID               (FieldVar(var, Symbol.symbol(ID), varleft))
-   (*| var LBRACK exp RBRACK    (SubscriptVar(var, exp, varleft))*)
+   | var LBRACK exp RBRACK    (SubscriptVar(var, exp, varleft))
+   | ID LBRACK exp RBRACK    (SubscriptVar(SimpleVar(Symbol.symbol(ID),IDleft), exp, IDleft))
 
 exp: var                       (VarExp(var))
    | NIL                       (NilExp)
@@ -191,9 +199,9 @@ letexp: LET declist IN explist END (LetExp { decs=List.rev declist,
                                              pos=LETleft })
 
 
-dec: fundeclist     (FunctionDec(List.rev(fundeclist)))
-   | vardec         (vardec)
-   | typedeclist    (TypeDec(List.rev(typedeclist)))
+dec: fundeclist    %prec DEC (FunctionDec(List.rev(fundeclist)))
+   | vardec                  (vardec)
+   | typedeclist   %prec DEC (TypeDec(List.rev(typedeclist)))
 
 declist: declist dec    (dec :: declist)
        | dec            ([dec])
@@ -230,9 +238,9 @@ typedec: TYPE ID EQ ty    ({ name=Symbol.symbol(ID),
                              ty=ty,
                              pos=TYPEleft })
 
+
 typedeclist: typedeclist typedec    (typedec :: typedeclist)
            | typedec                ([typedec])
-
 
 ty: ID                           (NameTy(Symbol.symbol(ID), IDleft))
   | LBRACE tyfieldlist RBRACE    (RecordTy(List.rev(tyfieldlist)))

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -112,8 +112,8 @@ opexp: exp PLUS exp      (OpExp { left=exp1,oper=PlusOp,   right=exp2,pos=exp1le
 
 
 callexp: ID LPAREN callexplist RPAREN    (CallExp { func=Symbol.symbol(ID),
-                                                          args=List.rev(callexplist),
-                                                          pos=IDleft })
+                                                    args=List.rev(callexplist),
+                                                    pos=IDleft })
 
 callexplist: callexplist COMMA exp    (exp :: callexplist)
            | exp                      ([exp])
@@ -121,8 +121,8 @@ callexplist: callexplist COMMA exp    (exp :: callexplist)
 
 
 recordexp: ID LBRACE recordexplist RBRACE    (RecordExp { fields=List.rev(recordexplist),
-                                                                typ=Symbol.symbol(ID),
-                                                                pos=IDleft })
+                                                          typ=Symbol.symbol(ID),
+                                                          pos=IDleft })
 
 recordexplist: recordexplist COMMA recordexpfields    (recordexpfields :: recordexplist)
              | recordexpfields                        ([recordexpfields])
@@ -139,61 +139,61 @@ seqexplist: seqexplist SEMICOLON exp    ((exp, expleft) :: seqexplist)
 
 
 assignexp: var ASSIGN exp    (AssignExp { var=var,
-                                                exp=exp,
-                                                pos=varleft })
+                                          exp=exp,
+                                          pos=varleft })
 
 
 ifthenelseexp: IF exp THEN exp ELSE exp    (IfExp { test=exp1,
-                                                          then'=exp2,
-                                                          else'=Option.SOME(exp3),
-                                                          pos=IFleft })
+                                                    then'=exp2,
+                                                    else'=Option.SOME(exp3),
+                                                    pos=IFleft })
 
 
 ifthenexp: IF exp THEN exp    (IfExp { test=exp1,
-                                             then'=exp2,
-                                             else'=Option.NONE,
-                                             pos=IFleft })
+                                       then'=exp2,
+                                       else'=Option.NONE,
+                                       pos=IFleft })
 
 
 whileexp: WHILE exp DO exp    (WhileExp { test=exp1,
-                                                body=exp2,
-                                                pos=WHILEleft })
+                                          body=exp2,
+                                          pos=WHILEleft })
 
 
 forexp: FOR ID ASSIGN exp TO exp DO exp    (ForExp { var=Symbol.symbol(ID),
-                                                           escape=ref true,
-                                                           lo=exp1,
-                                                           hi=exp2,
-                                                           body=exp3,
-                                                           pos=FORleft })
+                                                     escape=ref true,
+                                                     lo=exp1,
+                                                     hi=exp2,
+                                                     body=exp3,
+                                                     pos=FORleft })
 
 
 arrayexp: ID LBRACK exp RBRACK OF exp (ArrayExp { typ=Symbol.symbol(ID),
-                                                        size=exp1,
-                                                        init=exp2,
-                                                        pos=IDleft })
+                                                  size=exp1,
+                                                  init=exp2,
+                                                  pos=IDleft })
 
 
 letexp: LET declist IN exp END (LetExp { decs=List.rev declist,
-                                               body=exp,
-                                               pos=LETleft })
+                                         body=exp,
+                                         pos=LETleft })
 
 
-dec: fundeclist     (FunctionDec(fundeclist))
+dec: fundeclist     (FunctionDec(List.rev(fundeclist)))
    | vardec         (vardec)
-   | typedeclist    (TypeDec(typedeclist))
+   | typedeclist    (TypeDec(List.rev(typedeclist)))
 
 declist: declist dec    (dec :: declist)
        | dec            ([dec])
 
 
 fundec: FUNCTION ID LPAREN tyfieldlist RPAREN EQ exp             ({ name=Symbol.symbol(ID),
-                                                                    params=tyfieldlist,
+                                                                    params=List.rev(tyfieldlist),
                                                                     result=Option.NONE,
                                                                     body=exp,
                                                                     pos=FUNCTIONleft })
       | FUNCTION ID LPAREN tyfieldlist RPAREN COLON ID EQ exp    ({ name=Symbol.symbol(ID1),
-                                                                    params=tyfieldlist,
+                                                                    params=List.rev(tyfieldlist),
                                                                     result=Option.SOME(Symbol.symbol(ID2), ID2left),
                                                                     body=exp,
                                                                     pos=FUNCTIONleft })
@@ -203,15 +203,15 @@ fundeclist: fundeclist fundec    (fundec :: fundeclist)
 
 
 vardec: VAR ID ASSIGN exp            (VarDec { name=Symbol.symbol(ID),
-                                                     escape=ref true,
-                                                     typ=Option.NONE,
-                                                     init=exp,
-                                                     pos=VARleft })
+                                               escape=ref true,
+                                               typ=Option.NONE,
+                                               init=exp,
+                                               pos=VARleft })
      | VAR ID COLON ID ASSIGN exp    (VarDec { name=Symbol.symbol(ID1),
-                                                     escape=ref true,
-                                                     typ=Option.SOME(Symbol.symbol(ID2), ID2left),
-                                                     init=exp,
-                                                     pos=VARleft })
+                                               escape=ref true,
+                                               typ=Option.SOME(Symbol.symbol(ID2), ID2left),
+                                               init=exp,
+                                               pos=VARleft })
 
 
 typedec: TYPE ID EQ ty    ({ name=Symbol.symbol(ID),
@@ -222,9 +222,9 @@ typedeclist: typedeclist typedec    (typedec :: typedeclist)
            | typedec                ([typedec])
 
 
-ty: ID                           (NameTy (Symbol.symbol(ID), IDleft))
-  | LBRACE tyfieldlist RBRACE    (RecordTy tyfieldlist)
-  | ARRAY OF ID                  (ArrayTy (Symbol.symbol(ID), ARRAYleft))
+ty: ID                           (NameTy(Symbol.symbol(ID), IDleft))
+  | LBRACE tyfieldlist RBRACE    (RecordTy(List.rev(tyfieldlist)))
+  | ARRAY OF ID                  (ArrayTy(Symbol.symbol(ID), ARRAYleft))
 
 
 tyfield: ID COLON ID    ({ name=Symbol.symbol(ID1),

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -58,7 +58,7 @@ open Absyn;
 (* An assignment is a valueless expression *)
 %nonassoc ASSIGN
 (* The comparison operations are non-associative *)
-%nonassoc OR AND
+%left OR AND
 %nonassoc EQ NEQ LE LT GT GE
 (* This follows from common mathematics *)
 %left PLUS MINUS

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -127,6 +127,7 @@ recordexp: ID LBRACE recordexplist RBRACE    (Absyn.RecordExp { fields=List.rev(
 
 recordexplist: recordexplist COMMA recordexpfields    (recordexpfields :: recordexplist)
              | recordexpfields                        ([recordexpfields])
+             |                                        ([])
 
 recordexpfields: ID EQ exp    ((Symbol.symbol(ID), exp, IDleft))
 
@@ -234,3 +235,4 @@ tyfield: ID COLON ID    ({ name=Symbol.symbol(ID1),
 
 tyfieldlist: tyfieldlist COMMA tyfield    (tyfield :: tyfieldlist)
            | tyfield                      ([tyfield])
+           |                              ([])

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -52,8 +52,7 @@ open Absyn;
 (* This is used as the type and function declaration precedence
    so it does not interfere with the tokens type and function themselves *)
 %nonassoc DEC
-%nonassoc TYPE
-%nonassoc FUNCTION
+%nonassoc TYPE FUNCTION
 %nonassoc ID
 %nonassoc LBRACK
 

--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -19,6 +19,7 @@ open Absyn;
 %nonterm program         of exp
        | var             of var
        | exp             of exp
+       | opexp           of exp
        | callexp         of exp
        | callexplist     of exp list
        | recordexp       of exp
@@ -43,12 +44,6 @@ open Absyn;
        | ty              of ty
        | tyfield         of field
        | tyfieldlist     of field list
-
-
-
-
-
-
 
 %keyword WHILE FOR TO BREAK LET IN END FUNCTION VAR TYPE ARRAY IF THEN ELSE
          DO OF NIL
@@ -80,44 +75,40 @@ open Absyn;
 
 program : exp (exp)
 
-var: ID                    (SimpleVar(Symbol.symbol(ID), IDleft))
-   | var DOT ID            (FieldVar(var, Symbol.symbol(ID), varleft))
-   | var LBRACK exp RBRACK (SubscriptVar(var, exp, varleft))
+var: ID                       (SimpleVar(Symbol.symbol(ID), IDleft))
+   | var DOT ID               (FieldVar(var, Symbol.symbol(ID), varleft))
+   | var LBRACK exp RBRACK    (SubscriptVar(var, exp, varleft))
 
-exp: var                    (VarExp(var))
-   | NIL                    (NilExp)
-   | INT                    (IntExp(INT))
-   | MINUS exp %prec UMINUS (OpExp { left=IntExp(0), oper=MinusOp, right=exp, pos=MINUSleft })
-   | STRING                 (StringExp(STRING, STRINGleft))
-   | callexp                (callexp)
-   | exp PLUS exp           (OpExp { left=exp1, oper=PlusOp, right=exp2, pos=exp1left })
-   | exp MINUS exp          (OpExp { left=exp1, oper=MinusOp, right=exp2, pos=exp1left })
-   | exp TIMES exp          (OpExp { left=exp1, oper=TimesOp, right=exp2, pos=exp1left })
-   | exp DIVIDE exp         (OpExp { left=exp1, oper=DivideOp, right=exp2, pos=exp1left })
-   | exp AND exp            (IfExp { test=exp1,
-                                           then'=exp2,
-                                           else'=Option.SOME(IntExp(0)),
-                                           pos=exp1left })
-   | exp OR exp             (IfExp { test=exp1,
-                                           then'=IntExp(1),
-                                           else'=Option.SOME(exp2),
-                                           pos=exp1left })
-   | exp EQ exp             (OpExp { left=exp1, oper=EqOp, right=exp2, pos=exp1left })
-   | exp NEQ exp            (OpExp { left=exp1, oper=NeqOp, right=exp2, pos=exp1left })
-   | exp LT exp             (OpExp { left=exp1, oper=LtOp, right=exp2, pos=exp1left })
-   | exp LE exp             (OpExp { left=exp1, oper=LeOp, right=exp2, pos=exp1left })
-   | exp GT exp             (OpExp { left=exp1, oper=GtOp, right=exp2, pos=exp1left })
-   | exp GE exp             (OpExp { left=exp1, oper=GeOp, right=exp2, pos=exp1left })
-   | recordexp              (recordexp)
-   | seqexp                 (seqexp)
-   | assignexp              (assignexp)
-   | ifthenelseexp          (ifthenelseexp)
-   | ifthenexp              (ifthenexp)
-   | whileexp               (whileexp)
-   | forexp                 (forexp)
-   | BREAK                  (BreakExp(BREAKleft))
-   | arrayexp               (arrayexp)
-   | letexp                 (letexp)
+exp: var                       (VarExp(var))
+   | NIL                       (NilExp)
+   | INT                       (IntExp(INT))
+   | MINUS exp %prec UMINUS    (OpExp { left=IntExp(0), oper=MinusOp, right=exp, pos=MINUSleft })
+   | STRING                    (StringExp(STRING, STRINGleft))
+   | callexp                   (callexp)
+   | opexp                     (opexp)
+   | recordexp                 (recordexp)
+   | seqexp                    (seqexp)
+   | assignexp                 (assignexp)
+   | ifthenelseexp             (ifthenelseexp)
+   | ifthenexp                 (ifthenexp)
+   | whileexp                  (whileexp)
+   | forexp                    (forexp)
+   | BREAK                     (BreakExp(BREAKleft))
+   | arrayexp                  (arrayexp)
+   | letexp                    (letexp)
+
+opexp: exp PLUS exp      (OpExp { left=exp1,oper=PlusOp,   right=exp2,pos=exp1left })
+     | exp MINUS exp     (OpExp { left=exp1,oper=MinusOp,  right=exp2,pos=exp1left })
+     | exp TIMES exp     (OpExp { left=exp1,oper=TimesOp,  right=exp2,pos=exp1left })
+     | exp DIVIDE exp    (OpExp { left=exp1,oper=DivideOp, right=exp2,pos=exp1left })
+     | exp EQ exp        (OpExp { left=exp1,oper=EqOp,     right=exp2,pos=exp1left })
+     | exp NEQ exp       (OpExp { left=exp1,oper=NeqOp,    right=exp2,pos=exp1left })
+     | exp LT exp        (OpExp { left=exp1,oper=LtOp,     right=exp2,pos=exp1left })
+     | exp LE exp        (OpExp { left=exp1,oper=LeOp,     right=exp2,pos=exp1left })
+     | exp GT exp        (OpExp { left=exp1,oper=GtOp,     right=exp2,pos=exp1left })
+     | exp GE exp        (OpExp { left=exp1,oper=GeOp,     right=exp2,pos=exp1left })
+     | exp AND exp       (IfExp { test=exp1,then'=exp2,      else'=Option.SOME(IntExp(0)),pos=exp1left })
+     | exp OR exp        (IfExp { test=exp1,then'=IntExp(1), else'=Option.SOME(exp2),     pos=exp1left })
 
 
 callexp: ID LPAREN callexplist RPAREN    (CallExp { func=Symbol.symbol(ID),

--- a/test/parser/simple.sml
+++ b/test/parser/simple.sml
@@ -26,7 +26,7 @@ Test.test(fn () =>
  );
  Test.test(fn () =>
      let val actual = Parse.parse "fixtures/parser/simple/four.tig"
-         val expected = NegExp(IntExp(123), 1)
+         val expected = OpExp {left=IntExp(0), oper=MinusOp, right=IntExp(123), pos=1}
      in
           Test.assertEqIO(expected, actual, astPrint)
      end
@@ -47,16 +47,16 @@ Test.test(fn () =>
                 right=IntExp(1),
                 pos=2
             },2),
-            (OpExp {
-                left=IntExp(1),
-                oper=AndOp,
-                right=IntExp(1),
+            (IfExp {
+                test=IntExp(1),
+                then'=IntExp(1),
+                else'=Option.SOME(IntExp(0)),
                 pos=8
             },8),
-            (OpExp {
-                left=IntExp(1),
-                oper=OrOp,
-                right=IntExp(1),
+            (IfExp {
+                test=IntExp(1),
+                then'=IntExp(1),
+                else'=Option.SOME(IntExp(1)),
                 pos=14
             },14)
         ])


### PR DESCRIPTION
This is a major cleanup of the code for the grammar following some nice rules. The diff for this will be hard to read. I recommend just pulling this branch and looking through it.
- Creating lists of things is now standard.
- All rules are separated by two newlines, unless the rules are _directly_ related to each other, then separated by one newline.
- The order of productions now follows the `absyn.sml` structure closely to make things easier to read.
- All semantic actions are 4 spaces to the right of the largest production's right hand side.
- Records are now spread onto multiple lines.
### TODO
- [x] Ensure `List.rev` is called everywhere (I know it's now)
- [x] Check on what lists can be empty.
- [ ] Fix remaining shift reduce conflict.

```
error:  state 39: shift/reduce conflict (shift TYPE, reduce by rule 54)
error:  state 42: shift/reduce conflict (shift FUNCTION, reduce by rule 52)
```
