### PR TITLE
Left Associative And/Or

### DIFF
--- a/src/parser/tiger.grm
+++ b/src/parser/tiger.grm
@@ -58,7 +58,7 @@ open Absyn;
 (* An assignment is a valueless expression *)
 %nonassoc ASSIGN
 (* The comparison operations are non-associative *)
-%nonassoc OR AND
+%left OR AND
 %nonassoc EQ NEQ LE LT GT GE
 (* This follows from common mathematics *)
 %left PLUS MINUS


### PR DESCRIPTION
`queens.tig` has `row[r]=0 & diag1[r+c]=0 & diag2[r+7-c]=0`, so it's left associative.
